### PR TITLE
#3: Add an editor config file follow spacing conventions for code. 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# Drupal editor configuration normalization
+# @see http://editorconfig.org/
+
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# All files.
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[composer.{json,lock}]
+indent_size = 4


### PR DESCRIPTION
[issue #3 ](url)

Closes #3

.editorconfig file taken from [drupal.](https://git.drupalcode.org/project/drupal). Follows coding standards at https://www.drupal.org/docs/develop/standards
- [x ] This IS NOT a breaking change.

## Testing and review
1. Create a php file.
2. Tabs should be 2 spaces in editor (phpstorm or vscode)
3. Composer should be tab == 4 spaces in editor


